### PR TITLE
Fikser problemet mellom tailwind og navikt-css

### DIFF
--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,6 +1,7 @@
 /* eslint-disable no-undef */
 module.exports = {
   plugins: {
+    "postcss-import": {},
     tailwindcss: {},
     autoprefixer: {},
   },

--- a/src/main.css
+++ b/src/main.css
@@ -1,10 +1,11 @@
-@import '../node_modules/@navikt/ds-css';
-@import '../node_modules/@navikt/ds-css-internal';
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss/base";
+@import "../node_modules/@navikt/ds-css";
+@import "../node_modules/@navikt/ds-css-internal";
+@import "tailwindcss/components";
+@import "tailwindcss/utilities";
 
-html, body {
+html,
+body {
   height: 100%;
 }
 


### PR DESCRIPTION
Når css-importen tailwindcss/base kommer etter navikt, så vil det bli noen feil med visning av noen komponenter. Ett eksempel er Button som blir gjennomsiktig når den er Submit-knapp